### PR TITLE
Start checking against 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.3', '8.0']
+        php-version: ['7.3', '8.1']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:


### PR DESCRIPTION
Problem 1
    - Root composer.json requires phpdocumentor/graphviz ^2.0.0 -> satisfiable by phpdocumentor/graphviz[2.0.0].
    - phpdocumentor/graphviz 2.0.0 requires php ^7.2 || 8.0.* -> your php version (8.1.0) does not satisfy that requirement.
    
Will be fixed once https://github.com/phpDocumentor/GraphViz/pull/92 is merged.