### PR TITLE
Fix signed foreign keys

### DIFF
--- a/config/Migrations/20161029230233_StateMachineInit.php
+++ b/config/Migrations/20161029230233_StateMachineInit.php
@@ -48,7 +48,7 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => false,
+                'signed' => true,
             ])
             ->addColumn('name', 'string', [
                 'default' => null,
@@ -71,7 +71,7 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => false,
+                'signed' => true,
             ])
             ->addColumn('identifier', 'integer', [
                 'default' => null,
@@ -94,13 +94,13 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => false,
+                'signed' => true,
             ])
             ->addColumn('state_machine_item_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => false,
+                'signed' => true,
             ])
             ->addColumn('identifier', 'integer', [
                 'default' => null,
@@ -164,13 +164,13 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => false,
+                'signed' => true,
             ])
             ->addColumn('state_machine_process_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => false,
+                'signed' => true,
             ])
             ->addColumn('identifier', 'integer', [
                 'default' => null,


### PR DESCRIPTION
## PR Description

Migration command fails due to malformed foreign keys.
It appears that the foreign keys were recently defined as unsigned, while the referenced primary keys are signed by default.

## Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
